### PR TITLE
Correct spelling of "unserialize"

### DIFF
--- a/http/QueryString/unserialize.md
+++ b/http/QueryString/unserialize.md
@@ -1,4 +1,4 @@
-# void http\QueryString::unseralize(string $serialized)
+# void http\QueryString::unserialize(string $serialized)
 
 Implements Serializable.
 


### PR DESCRIPTION
I copied and pasted that name into a program I was writing and it caused an error.  Then I realized there was a typo.